### PR TITLE
updated aq. to sensors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,9 @@ The data displayed has been produced by low-cost devices developed by [Connected
 
 This is the changelog for the air quality web interface and its associated HTTP API.
 
- - `[API]` refers to changes to the [HTTP API](https://aq.connectedhumber.org/__nightdocs/05-API-Docs.html).
+ - `[API]` refers to changes to the [HTTP API](https://sensors.connectedhumber.org/__nightdocs/05-API-Docs.html).
  - `[Code]` refers to internal changes to the code that have no direct impact on the web interface or the HTTP API, but are significant enough to warrant note.
- - `[Docs]` refers to changes to the [documentation](https://aq.connectedhumber.org/__nightdocs/00-Welcome.html).
+ - `[Docs]` refers to changes to the [documentation](https://sensors.connectedhumber.org/__nightdocs/00-Welcome.html).
 
 
 ## v0.14


### PR DESCRIPTION
Top most [API] and [documentation] links still pointed to aq. site and should be sensors. site

<!-- Thanks for opening a pull request! Please tick the box below to agree that your contribution be released under the same license as this repository. -->

 - [x] I agree to release my contribution under the _Mozilla Public License 2.0_, as documented in the [LICENSE](https://github.com/ConnectedHumber/Air-Quality-Web/blob/master/LICENSE) file in this repository.

<!-- Please include a description of what the PR includes below :-) -->
